### PR TITLE
Make infect_an_assertion available to gem

### DIFF
--- a/lib/minitest/sequel/columns.rb
+++ b/lib/minitest/sequel/columns.rb
@@ -1,4 +1,5 @@
 # require "minitest/sequel"
+require 'minitest/spec'
 
 # reopening to add schema validation functionality
 module Minitest::Assertions


### PR DESCRIPTION
Require minitest/spec to include Module infect_an_assertion.

Fixes an issue where `infect_an_assertion` was not found.